### PR TITLE
Fix race condition when adding sharp images to products

### DIFF
--- a/helpers/index.js
+++ b/helpers/index.js
@@ -302,12 +302,12 @@ const mapMediaToNodes = async ({
       }
 
       if (n.images && n.images.length) {
-        await n.images.map(async image => {
-          downloadMedia({
+        for (let image of n.images) {
+          await downloadMedia({
             image,
             ...commonParams,
           })
-        })
+        }
         return n
       } else if (n.image && n.image.id) {
         const { image } = n


### PR DESCRIPTION
Sometimes gatsby images are not loaded for products because it's not waiting for the `downloadMedia` promise to complete. This PR fixes that