### PR TITLE
avoid typo of fieldname

### DIFF
--- a/helpers/index.js
+++ b/helpers/index.js
@@ -241,7 +241,7 @@ const mapGroupedProducts = (nodes) => {
  * @return The camelCase field name
  */
 const normaliseFieldName = (name) => {
-  const parts = name.split("/");
+  const parts = name.split("/").map(fieldname => fieldname.toLowerCase());
   return parts.reduce((whole, partial) => {
     if (whole === "") {
       return whole.concat(partial);


### PR DESCRIPTION
Fix typo of fields names like explained below: 
if some devs type `products/caTEGorIes` by mistake (in fact it must be `products/categories`) to get wcProductsCategories with graphql query and to avoid this i transform all fields names to lowercase before normalize them