### PR TITLE
Allow querystring auth to override basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ plugins:[
       },
       // Array of strings with fields you'd like to create nodes for...
       fields: ['products', 'products/categories'],
+      // Send the API keys as query string parameters instead of using the authorization header
+      // OPTIONAL: defaults to false
+      query_string_auth: true,
       // Version of the woocommerce API to use
       // OPTIONAL: defaults to 'wc/v3'
       api_version: 'wc/v3',

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ plugins:[
       fields: ['products', 'products/categories'],
       // Send the API keys as query string parameters instead of using the authorization header
       // OPTIONAL: defaults to false
-      query_string_auth: true,
+      query_string_auth: false,
       // Version of the woocommerce API to use
       // OPTIONAL: defaults to 'wc/v3'
       api_version: 'wc/v3',

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -26,6 +26,7 @@ exports.sourceNodes = async (
     api_version = "wc/v3",
     per_page,
     wpAPIPrefix = null,
+    query_string_auth = false,
   } = configOptions;
 
   // set up WooCommerce node api tool
@@ -35,6 +36,7 @@ exports.sourceNodes = async (
     consumerSecret: api_keys.consumer_secret,
     version: api_version,
     wpAPIPrefix,
+    queryStringAuth: query_string_auth,
   });
 
   // Fetch Node data for a given field name


### PR DESCRIPTION
The WooCommerce JS library allows the API key and username to be used as query string arguments instead of the Basic authorization header.

It would be grand if we could add this ability to the plugin because our server setup does not allow the authorization header to be used and this is the only workaround.