### PR TITLE
Add wordpress_parent_id to nodes with parents

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -91,6 +91,7 @@ exports.sourceNodes = async (
         ...node,
         id: createNodeId(`woocommerce-${fieldName}-${node.id}`),
         wordpress_id: node.id,
+        wordpress_parent_id: node.parent,
         __type: `wc${fieldName[0].toUpperCase() + fieldName.slice(1)}`,
       }));
       nodes = nodes.concat(tempNodes);


### PR DESCRIPTION
When generating some WooCommerce nodes (eg. product categories), a "parent" field is used for the wordpress parent category id. In this case, the parent field will be overridden by the GraphQL parent node.

This solves that issue, and when the node.parent is "undefined", wordpress_parent_id field is not generated