### PR TITLE
Support for Metadata fields and Misc Data

### DIFF
--- a/__tests__/helpers-misc-data.test.js
+++ b/__tests__/helpers-misc-data.test.js
@@ -1,0 +1,41 @@
+const { getWCNodeId, mapNodeNormalizeMetadata } = require("../helpers/misc-data");
+
+describe("Helpers - Misc Data:", () => {
+
+  describe("getWCNodeId", () => {
+    const fieldName = 'data';
+
+    it("should properly return id when exists", () => {
+      const node = {id: 'testid'};
+      expect(getWCNodeId(node, fieldName)).toEqual(node.id);
+    });
+
+    it("should properly return composed code-id when code prop exists", () => {
+      const node = {code: 'abc123'};
+      expect(getWCNodeId(node, fieldName)).toEqual(`${fieldName}-${node.code}`);
+    });
+
+    it("should properly return a random id when id or code does not exists", () => {
+      const node = {};
+      expect(getWCNodeId(node, fieldName)).toContain(fieldName);
+    });
+  });
+
+  describe("mapNodeNormalizeMetadata", () => {
+    it("should always return metadata as a string array", () => {
+      const nodeNoMetadata = {};
+      const nodeMetadataArray = {meta_data: [{value: ["val"]}]};
+      const nodeMetadataString = {meta_data: [{value: "stringval"}]};
+      const nodeMetadataNumber = {meta_data: [{value: 50}]};
+
+      const nodes = [nodeNoMetadata, nodeMetadataArray, nodeMetadataString, nodeMetadataNumber];
+      const nodesWithMeta = mapNodeNormalizeMetadata(nodes);
+      expect(nodesWithMeta[0].meta_data).toBeFalsy();
+      expect(nodesWithMeta[1].meta_data[0].value).toEqual(nodeMetadataArray.meta_data[0].value);
+      expect(nodesWithMeta[2].meta_data[0].value).toEqual([nodeMetadataString.meta_data[0].value]);
+      expect(nodesWithMeta[3].meta_data[0].value).toEqual([String(nodeMetadataNumber.meta_data[0].value)]);
+    });
+
+  });
+
+});

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -14,7 +14,7 @@ const {
 const {
   getWCNodeId,
   mapNodeNormalizeMetadata
-} = require("./helpers/addon-data");
+} = require("./helpers/misc-data");
 
 exports.sourceNodes = async (
     { actions, createNodeId, createContentDigest, store, cache },

--- a/helpers/addon-data.js
+++ b/helpers/addon-data.js
@@ -1,0 +1,27 @@
+const isAddonData = (fieldName) => fieldName.startsWith('data');
+const randomId = () => Math.floor(Math.random()*10000000);
+const getWCNodeId = (node, fieldName) => {
+  if (!node) {
+    console.log('Node is invalid:', node, fieldName);
+    return node;
+  }
+  return node && node.id ? node.id : node && node.code ? `${fieldName}-${node.code}` : `${fieldName}-${randomId()}`;
+};
+
+const mapNodeNormalizeMetadata = (nodes) => {
+  return nodes.map(node => {
+    if (!node.meta_data || node.meta_data.length === 0) return node;
+    node.meta_data = node.meta_data.map((meta) => {
+      let value = Array.isArray(meta.value) ? meta.value : [meta.value];
+      value = value.map(val => String(val));
+      return {...meta, ...{value}};
+    });
+    return node;
+  })
+};
+
+
+module.exports = {
+  getWCNodeId,
+  mapNodeNormalizeMetadata
+};

--- a/helpers/misc-data.js
+++ b/helpers/misc-data.js
@@ -1,4 +1,4 @@
-const isAddonData = (fieldName) => fieldName.startsWith('data');
+// const isAddonData = (fieldName) => fieldName.startsWith('data');
 const randomId = () => Math.floor(Math.random()*10000000);
 const getWCNodeId = (node, fieldName) => {
   if (!node) {
@@ -11,12 +11,12 @@ const getWCNodeId = (node, fieldName) => {
 const mapNodeNormalizeMetadata = (nodes) => {
   return nodes.map(node => {
     if (!node.meta_data || node.meta_data.length === 0) return node;
-    node.meta_data = node.meta_data.map((meta) => {
+    const meta_data = node.meta_data.map((meta) => {
       let value = Array.isArray(meta.value) ? meta.value : [meta.value];
       value = value.map(val => String(val));
       return {...meta, ...{value}};
     });
-    return node;
+    return {...node, ...{meta_data}};
   })
 };
 


### PR DESCRIPTION
Hello @pasdo501 

I have been working on a ecom site with Gatbsy and WooCommerce.
I have been using this plugin to feed my site with the WooCommerce info, but I found an issue, where the products metadata is not arriving properly.

In particular Yoast SEO config.

Basically what occurs is that metadata is arriving but not the metadata.value.
I'm not a GraphQL expert, but I assumed the error occur because the metadata value type varies.
In some cases it is a string, in others a number and in others an array.

In order to solve that, I have standardize the metadata field to always be a string array.

Also, I found another issue in specific when querying misc data such as `data/countries` where the data is not successfully returned, because they have no ids.
I'm no Wordpress expert either, but seems that this information is not stored in database, rather in files.
And due to the this, all the nodes comes without an id.

I have modified the process so that in the cases where the nodes have no ids, it can compute an id based on a `code` property and the field name. Example `datacountries/USA`.

I have also created some unit testing for the new code.

I have decided to add a new file called `misc_data.js` to not add additional logic to the current helper file.

Final comment, I'm seeing several formatting changes on the `gatsby-node` file, although I just added the usage of `getWCNodeId` and `mapNodeNormalizeMetadata`, I'm wondering now if my IDE did those automatically.